### PR TITLE
add forum navigation buttons to footer when viewing thread

### DIFF
--- a/src/ISS/templates/thread.html
+++ b/src/ISS/templates/thread.html
@@ -118,6 +118,21 @@
       </form>
     {% endif %}
 
+          {% block navigation %}
+        <div class="breadcrumb">
+          <h3>Navigation</h3>
+
+          <div class="crumbs">
+            <a class="crumb" href="{% url "forum-index" %}">
+              {{ config.forum_name }}
+            </a>
+
+            {% block breadcrumb %}
+            {% endblock %}
+          </div>
+        </div>
+      {% endblock %}
+
     {% if not thread.can_reply %}
       <div class="page-message">
         <div class="icon-container">


### PR DESCRIPTION
i copied the block for forum navigation at the top of the thread and pasted it above the footer. hopefully this will add the forum selection buttons to the bottom of a thread. 